### PR TITLE
fix: use in-memory storage for Mastra on Vercel serverless

### DIFF
--- a/mastra/index.ts
+++ b/mastra/index.ts
@@ -31,7 +31,7 @@ const workspace = new Workspace({
 
 const storage = new LibSQLStore({
   id: "muse-storage",
-  url: process.env.MASTRA_STORAGE_URL || "file:./mastra.db",
+  url: process.env.MASTRA_STORAGE_URL || (process.env.VERCEL ? ":memory:" : "file:./mastra.db"),
 });
 
 const observability = new Observability({


### PR DESCRIPTION
## Summary
- Fix `ConnectionFailed("Unable to open connection to local database ./mastra.db: 14")` error on Vercel production
- Fall back to `:memory:` LibSQLStore when `VERCEL` env var is detected (read-only filesystem)
- Local development continues using `file:./mastra.db` (Mastra Studio traces remain available)

## Test plan
- [x] `bun run build` passes without errors
- [ ] Verify logic model creation works on Vercel preview deployment