### PR TITLE
fix(canvas): remove branding and improve export image quality

### DIFF
--- a/components/canvas/ExportImageDialog.tsx
+++ b/components/canvas/ExportImageDialog.tsx
@@ -36,7 +36,7 @@ export function ExportImageDialog({ open, onOpenChange, nodes }: ExportImageDial
   useEffect(() => {
     if (open && status === "idle" && !hasTriggeredRef.current) {
       hasTriggeredRef.current = true;
-      generate(nodes);
+      generate(nodes, "export");
     }
   }, [open, status, nodes, generate]);
 
@@ -84,7 +84,7 @@ export function ExportImageDialog({ open, onOpenChange, nodes }: ExportImageDial
           status={status}
           result={result}
           error={error}
-          onRetry={() => generate(nodes)}
+          onRetry={() => generate(nodes, "export")}
         />
 
         {/* Action Buttons */}

--- a/hooks/useCanvasImage.ts
+++ b/hooks/useCanvasImage.ts
@@ -6,11 +6,13 @@ import { generateCanvasImage } from "@/lib/generate-canvas-image";
 
 export type CanvasImageStatus = "idle" | "generating" | "ready" | "error";
 
+export type CanvasImageMode = "export" | "ogp";
+
 export interface UseCanvasImageResult {
   status: CanvasImageStatus;
   result: CanvasImageResult | null;
   error: string | null;
-  generate: (nodes: Node[]) => Promise<CanvasImageResult | null>;
+  generate: (nodes: Node[], mode?: CanvasImageMode) => Promise<CanvasImageResult | null>;
   reset: () => void;
   setResult: (result: CanvasImageResult) => void;
 }
@@ -23,55 +25,71 @@ export function useCanvasImage(): UseCanvasImageResult {
   const [result, setResult] = useState<CanvasImageResult | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const generate = useCallback(async (nodes: Node[]): Promise<CanvasImageResult | null> => {
-    if (nodes.length === 0) {
-      setError("Cannot generate image from empty canvas");
-      setStatus("error");
-      return null;
-    }
-
-    setStatus("generating");
-    setError(null);
-
-    try {
-      // Get the React Flow viewport element
-      const viewportElement = document.querySelector(".react-flow__viewport") as HTMLElement;
-      if (!viewportElement) {
-        throw new Error("React Flow viewport not found");
+  const generate = useCallback(
+    async (nodes: Node[], mode: CanvasImageMode = "ogp"): Promise<CanvasImageResult | null> => {
+      if (nodes.length === 0) {
+        setError("Cannot generate image from empty canvas");
+        setStatus("error");
+        return null;
       }
 
-      // Calculate bounds and viewport for optimal capture
-      const nodesBounds = getNodesBounds(nodes);
-      // Ensure minimum dimensions to prevent division by zero or Infinity
-      const imageWidth = Math.max(nodesBounds.width, 100);
-      const imageHeight = Math.max(nodesBounds.height, 100);
-      const viewport = getViewportForBounds(nodesBounds, imageWidth, imageHeight, 0.5, 2, 0.2);
+      setStatus("generating");
+      setError(null);
 
-      const sourceDataUrl = await toPng(viewportElement, {
-        backgroundColor: "#f9fafb",
-        width: imageWidth,
-        height: imageHeight,
-        pixelRatio: 1, // Prevent memory issues on large canvases
-        style: {
-          width: `${imageWidth}px`,
-          height: `${imageHeight}px`,
-          transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
-        },
-      });
+      try {
+        // Get the React Flow viewport element
+        const viewportElement = document.querySelector(".react-flow__viewport") as HTMLElement;
+        if (!viewportElement) {
+          throw new Error("React Flow viewport not found");
+        }
 
-      const canvasImageResult = await generateCanvasImage({ sourceDataUrl });
+        // Calculate bounds and viewport for optimal capture
+        const nodesBounds = getNodesBounds(nodes);
+        // Ensure minimum dimensions to prevent division by zero or Infinity
+        const imageWidth = Math.max(nodesBounds.width, 100);
+        const imageHeight = Math.max(nodesBounds.height, 100);
+        const viewport = getViewportForBounds(nodesBounds, imageWidth, imageHeight, 0.5, 2, 0.2);
 
-      setResult(canvasImageResult);
-      setStatus("ready");
-      return canvasImageResult;
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : "Failed to generate image";
-      setError(errorMessage);
-      setStatus("error");
-      console.error("Failed to generate canvas image:", err);
-      return null;
-    }
-  }, []);
+        const isExport = mode === "export";
+        const pixelRatio = isExport ? 2 : 1;
+
+        const sourceDataUrl = await toPng(viewportElement, {
+          backgroundColor: "#f9fafb",
+          width: imageWidth,
+          height: imageHeight,
+          pixelRatio,
+          style: {
+            width: `${imageWidth}px`,
+            height: `${imageHeight}px`,
+            transform: `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
+          },
+        });
+
+        let canvasImageResult: CanvasImageResult;
+
+        if (isExport) {
+          // Export mode: use the high-res capture directly without OGP compositing
+          const res = await fetch(sourceDataUrl);
+          const blob = await res.blob();
+          canvasImageResult = { dataUrl: sourceDataUrl, blob };
+        } else {
+          // OGP mode: composite into 1200×630 branded image
+          canvasImageResult = await generateCanvasImage({ sourceDataUrl });
+        }
+
+        setResult(canvasImageResult);
+        setStatus("ready");
+        return canvasImageResult;
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : "Failed to generate image";
+        setError(errorMessage);
+        setStatus("error");
+        console.error("Failed to generate canvas image:", err);
+        return null;
+      }
+    },
+    [],
+  );
 
   const reset = useCallback(() => {
     setStatus("idle");


### PR DESCRIPTION
## Summary
- Remove header (MUSE by Beaconlabs), footer (muse.beaconlabs.io), and excess padding from exported images
- Export mode uses `pixelRatio: 2` high-res capture directly, skipping OGP compositing
- IPFS save retains existing 1200×630 branded OGP format

## Test plan
- [x] Create a logic model on canvas, export image → verify no branding and readable high-res output
- [x] Save to IPFS → verify OGP image (1200×630 + header/footer) is still generated
- [x] Verify both Copy Image and Download work correctly