### PR TITLE
refactor: make metrics generation optional with collapsible options UI

### DIFF
--- a/app/api/workflow/stream/route.ts
+++ b/app/api/workflow/stream/route.ts
@@ -16,6 +16,7 @@ const logger = createLogger({ module: "api:workflow-stream" });
 const RequestSchema = z.object({
   goal: z.string().min(1).max(1000),
   enableExternalSearch: z.boolean().default(false),
+  enableMetrics: z.boolean().default(false),
 });
 
 function formatSSE(event: WorkflowSSEEvent): string {
@@ -44,7 +45,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const { goal, enableExternalSearch } = parsed.data;
+  const { goal, enableExternalSearch, enableMetrics } = parsed.data;
 
   const stream = new ReadableStream({
     async start(controller) {
@@ -62,7 +63,9 @@ export async function POST(request: NextRequest) {
       try {
         const workflow = mastra.getWorkflow("logicModelWithEvidenceWorkflow");
         const run = await workflow.createRun();
-        const output = await run.stream({ inputData: { goal, enableExternalSearch } });
+        const output = await run.stream({
+          inputData: { goal, enableExternalSearch, enableMetrics },
+        });
 
         // Set up timeout
         const timeoutPromise = new Promise<never>((_, reject) => {

--- a/components/canvas/GenerateLogicModelDialog.tsx
+++ b/components/canvas/GenerateLogicModelDialog.tsx
@@ -39,6 +39,7 @@ const generateLogicModelSchema = z.object({
     .min(1, "Please enter your goal")
     .max(1000, "Goal must be 1000 characters or less"),
   enableExternalSearch: z.boolean(),
+  enableMetrics: z.boolean(),
 });
 
 type GenerateLogicModelFormData = z.infer<typeof generateLogicModelSchema>;
@@ -95,6 +96,7 @@ export function GenerateLogicModelDialog({ onGenerate }: GenerateLogicModelDialo
     defaultValues: {
       goal: "",
       enableExternalSearch: false,
+      enableMetrics: false,
     },
   });
 
@@ -172,7 +174,10 @@ export function GenerateLogicModelDialog({ onGenerate }: GenerateLogicModelDialo
     setStepDialogOpen(true);
 
     processedEventCountRef.current = 0;
-    await startWorkflow(data.goal, data.enableExternalSearch);
+    await startWorkflow(data.goal, {
+      enableExternalSearch: data.enableExternalSearch,
+      enableMetrics: data.enableMetrics,
+    });
   };
 
   // Cleanup on unmount
@@ -230,6 +235,32 @@ export function GenerateLogicModelDialog({ onGenerate }: GenerateLogicModelDialo
                 )}
               />
             )}
+            <FormField
+              control={form.control}
+              name="enableMetrics"
+              render={({ field }) => (
+                <FormItem className="flex items-center justify-between">
+                  <div className="flex items-center gap-1.5">
+                    <FormLabel className="text-sm font-normal">{t("metricsLabel")}</FormLabel>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Info className="text-muted-foreground h-4 w-4 cursor-help" />
+                      </TooltipTrigger>
+                      <TooltipContent side="top" className="max-w-[260px]">
+                        {t("metricsTooltip")}
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                      disabled={isRunning}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
             <FormField
               control={form.control}
               name="goal"

--- a/components/canvas/GenerateLogicModelDialog.tsx
+++ b/components/canvas/GenerateLogicModelDialog.tsx
@@ -3,12 +3,13 @@
 import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Info } from "lucide-react";
+import { ChevronDown, Info } from "lucide-react";
 import { useTranslations } from "next-intl";
 import * as z from "zod";
 import { GenerationTimeInfo } from "@/components/canvas/GenerationTimeInfo";
 import { useStepProcessDialogContext } from "@/components/step-process-dialog";
 import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import {
   Dialog,
   DialogContent,
@@ -205,62 +206,6 @@ export function GenerateLogicModelDialog({ onGenerate }: GenerateLogicModelDialo
         </DialogHeader>
         <Form {...form}>
           <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
-            {EXTERNAL_SEARCH_ENABLED && (
-              <FormField
-                control={form.control}
-                name="enableExternalSearch"
-                render={({ field }) => (
-                  <FormItem className="flex items-center justify-between">
-                    <div className="flex items-center gap-1.5">
-                      <FormLabel className="text-sm font-normal">
-                        {t("externalSearchLabel")}
-                      </FormLabel>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Info className="text-muted-foreground h-4 w-4 cursor-help" />
-                        </TooltipTrigger>
-                        <TooltipContent side="top" className="max-w-[260px]">
-                          {t("externalSearchTooltip")}
-                        </TooltipContent>
-                      </Tooltip>
-                    </div>
-                    <FormControl>
-                      <Switch
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                        disabled={isRunning}
-                      />
-                    </FormControl>
-                  </FormItem>
-                )}
-              />
-            )}
-            <FormField
-              control={form.control}
-              name="enableMetrics"
-              render={({ field }) => (
-                <FormItem className="flex items-center justify-between">
-                  <div className="flex items-center gap-1.5">
-                    <FormLabel className="text-sm font-normal">{t("metricsLabel")}</FormLabel>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Info className="text-muted-foreground h-4 w-4 cursor-help" />
-                      </TooltipTrigger>
-                      <TooltipContent side="top" className="max-w-[260px]">
-                        {t("metricsTooltip")}
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
-                  <FormControl>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                      disabled={isRunning}
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
             <FormField
               control={form.control}
               name="goal"
@@ -280,6 +225,70 @@ export function GenerateLogicModelDialog({ onGenerate }: GenerateLogicModelDialo
                 </FormItem>
               )}
             />
+            <Collapsible>
+              <CollapsibleTrigger className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-sm transition-colors [&[data-state=open]>svg]:rotate-180">
+                <ChevronDown className="h-4 w-4 transition-transform" />
+                {t("optionsLabel")}
+              </CollapsibleTrigger>
+              <CollapsibleContent className="space-y-4 pt-3">
+                {EXTERNAL_SEARCH_ENABLED && (
+                  <FormField
+                    control={form.control}
+                    name="enableExternalSearch"
+                    render={({ field }) => (
+                      <FormItem className="flex items-center justify-between">
+                        <div className="flex items-center gap-1.5">
+                          <FormLabel className="text-sm font-normal">
+                            {t("externalSearchLabel")}
+                          </FormLabel>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Info className="text-muted-foreground h-4 w-4 cursor-help" />
+                            </TooltipTrigger>
+                            <TooltipContent side="top" className="max-w-[260px]">
+                              {t("externalSearchTooltip")}
+                            </TooltipContent>
+                          </Tooltip>
+                        </div>
+                        <FormControl>
+                          <Switch
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                            disabled={isRunning}
+                          />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                )}
+                <FormField
+                  control={form.control}
+                  name="enableMetrics"
+                  render={({ field }) => (
+                    <FormItem className="flex items-center justify-between">
+                      <div className="flex items-center gap-1.5">
+                        <FormLabel className="text-sm font-normal">{t("metricsLabel")}</FormLabel>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Info className="text-muted-foreground h-4 w-4 cursor-help" />
+                          </TooltipTrigger>
+                          <TooltipContent side="top" className="max-w-[260px]">
+                            {t("metricsTooltip")}
+                          </TooltipContent>
+                        </Tooltip>
+                      </div>
+                      <FormControl>
+                        <Switch
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                          disabled={isRunning}
+                        />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+              </CollapsibleContent>
+            </Collapsible>
 
             <DialogFooter>
               <Button

--- a/docs/mastra-agents.md
+++ b/docs/mastra-agents.md
@@ -58,7 +58,7 @@ sequenceDiagram
     Note over Workflow, Agent: Workflow Step 1: Generate Logic Model Structure
     Workflow->>Agent: logicModelAgent.generate(goal, maxSteps: 12)
     Agent->>Agent: Stage 1: Analyze Intervention (domain, goals)
-    Agent->>Agent: Stage 2: Generate Cards (with metrics)
+    Agent->>Agent: Stage 2: Generate Cards (optionally with metrics)
     Agent->>Agent: Stage 3: Design Connections (4-Test Framework)
     Agent->>Agent: Stage 4: Self-Critique (validation checklists)
     Agent->>Tool: Stage 5: Call logicModelTool (ONCE)
@@ -278,9 +278,9 @@ Theory of Change specialist with structured 5-stage workflow:
 
 #### Stage 2: Generate Cards
 
-- Creates 1-2 cards per stage with title (max 100 chars), description (max 200 chars), and metrics
+- Creates 1-2 cards per stage with title (max 100 chars), description (max 200 chars), and optionally metrics
 - Stages: Activities → Outputs → Outcomes-Short (0-6 months) → Outcomes-Intermediate (6-18 months) → Impact (18+ months)
-- Each card requires 1 metric object with name, measurementMethod, and frequency fields
+- When `enableMetrics` is true, each card includes 1 metric object with name, measurementMethod, and frequency fields. When disabled (default), metrics arrays are empty.
 
 #### Stage 3: Design Connections with 4-Test Framework
 
@@ -305,10 +305,10 @@ Theory of Change specialist with structured 5-stage workflow:
 ### Common Mistakes Prevention
 
 - ❌ **TOP MISTAKE #1**: targetContext as object instead of string
-- ❌ **TOP MISTAKE #2**: Metrics as strings instead of objects
+- ❌ **TOP MISTAKE #2**: Metrics as strings instead of objects (when metrics enabled)
 - ❌ **TOP MISTAKE #3**: Too many (>15) or too few (<8) connections
 - ❌ **TOP MISTAKE #4**: Weak/indirect connections to hit count
-- ❌ **TOP MISTAKE #5**: Invalid frequency values
+- ❌ **TOP MISTAKE #5**: Invalid frequency values (when metrics enabled)
 
 ### 2. Evidence Search Agent
 
@@ -380,6 +380,9 @@ Main UI component with 4-step process:
 - Step 4: "complete" - Final state
 - Real-time step progress via `useWorkflowStream` hook and SSE route (`/api/workflow/stream`)
 - Form validation with Zod
+- Collapsible "Options" section with:
+  - `enableExternalSearch` toggle (visible when `EXTERNAL_SEARCH_ENABLED=true`)
+  - `enableMetrics` toggle (default OFF) — controls whether the agent generates metrics for cards
 
 ### logic-model-with-evidence.ts
 
@@ -389,6 +392,8 @@ Production workflow with 4 steps (including Step 2.5):
 
 **Step 1: Generate Logic Model Structure**
 
+- Reads `enableMetrics` from workflow init data (default: false)
+- Conditionally instructs agent to generate or skip metrics
 - Validates agent called logicModelTool and returned valid canvas data with detailed logging
 - Extracts canvasData from tool results with detailed logging
 
@@ -477,7 +482,7 @@ Tool for generating logic model structure:
 1. Authenticate via `BOT_API_KEY` header (optional, skipped if `BOT_API_KEY` env var is not configured)
 2. Validate request body with `CompactRequestSchema` (`chatHistory: ChatMessage[]`)
 3. Extract goal from user messages in the conversation
-4. Run `logicModelWithEvidenceWorkflow` with `enableExternalSearch: true` (always enabled)
+4. Run `logicModelWithEvidenceWorkflow` with `enableExternalSearch: true` and `enableMetrics: false` (default)
 5. Validate output with `CanvasDataSchema`
 6. Upload canvas data to IPFS via Pinata
 7. Return `CompactResponse`: `{ canvasUrl, canvasId, summary: { extractedIssues, intervention, targetContext } }`

--- a/hooks/useWorkflowStream.ts
+++ b/hooks/useWorkflowStream.ts
@@ -39,136 +39,140 @@ export function useWorkflowStream() {
   const [stepEvents, setStepEvents] = useState<StepEvent[]>([]);
   const abortControllerRef = useRef<AbortController | null>(null);
 
-  const startWorkflow = useCallback(async (goal: string, enableExternalSearch: boolean = false) => {
-    // Abort any existing stream
-    abortControllerRef.current?.abort();
+  const startWorkflow = useCallback(
+    async (goal: string, options?: { enableExternalSearch?: boolean; enableMetrics?: boolean }) => {
+      const { enableExternalSearch = false, enableMetrics = false } = options ?? {};
+      // Abort any existing stream
+      abortControllerRef.current?.abort();
 
-    const abortController = new AbortController();
-    abortControllerRef.current = abortController;
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
 
-    setState({
-      status: "running",
-      currentStepId: null,
-      error: null,
-      errorCategory: null,
-      rawError: null,
-      failedStepId: null,
-      canvasData: null,
-    });
-    setStepEvents([]);
-
-    // Client-side timeout
-    const timeoutId = setTimeout(() => {
-      abortController.abort();
-      setState((prev) => ({
-        ...prev,
-        status: "error",
-        error: "Workflow timed out",
-      }));
-    }, WORKFLOW_TIMEOUT_MS + 10_000);
-
-    try {
-      const response = await fetch("/api/workflow/stream", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ goal, enableExternalSearch }),
-        signal: abortController.signal,
+      setState({
+        status: "running",
+        currentStepId: null,
+        error: null,
+        errorCategory: null,
+        rawError: null,
+        failedStepId: null,
+        canvasData: null,
       });
+      setStepEvents([]);
 
-      if (!response.ok) {
-        const errorBody = await response.json().catch(() => ({}));
-        throw new Error((errorBody as Record<string, string>).error || `HTTP ${response.status}`);
-      }
+      // Client-side timeout
+      const timeoutId = setTimeout(() => {
+        abortController.abort();
+        setState((prev) => ({
+          ...prev,
+          status: "error",
+          error: "Workflow timed out",
+        }));
+      }, WORKFLOW_TIMEOUT_MS + 10_000);
 
-      const reader = response.body?.getReader();
-      if (!reader) {
-        throw new Error("No response stream");
-      }
+      try {
+        const response = await fetch("/api/workflow/stream", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ goal, enableExternalSearch, enableMetrics }),
+          signal: abortController.signal,
+        });
 
-      const decoder = new TextDecoder();
-      let buffer = "";
+        if (!response.ok) {
+          const errorBody = await response.json().catch(() => ({}));
+          throw new Error((errorBody as Record<string, string>).error || `HTTP ${response.status}`);
+        }
 
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
+        const reader = response.body?.getReader();
+        if (!reader) {
+          throw new Error("No response stream");
+        }
 
-        buffer += decoder.decode(value, { stream: true });
+        const decoder = new TextDecoder();
+        let buffer = "";
 
-        // Parse SSE lines
-        const lines = buffer.split("\n\n");
-        buffer = lines.pop() || "";
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
 
-        for (const chunk of lines) {
-          const dataLine = chunk.split("\n").find((line) => line.startsWith("data: "));
-          if (!dataLine) continue;
+          buffer += decoder.decode(value, { stream: true });
 
-          const jsonStr = dataLine.slice(6); // Remove "data: " prefix
-          let event: WorkflowSSEEvent;
-          try {
-            event = JSON.parse(jsonStr) as WorkflowSSEEvent;
-          } catch {
-            continue;
-          }
+          // Parse SSE lines
+          const lines = buffer.split("\n\n");
+          buffer = lines.pop() || "";
 
-          switch (event.type) {
-            case "step-start":
-              setState((prev) => ({
-                ...prev,
-                currentStepId: event.stepId,
-              }));
-              setStepEvents((prev) => [...prev, { type: "step-start", stepId: event.stepId }]);
-              break;
+          for (const chunk of lines) {
+            const dataLine = chunk.split("\n").find((line) => line.startsWith("data: "));
+            if (!dataLine) continue;
 
-            case "step-finish":
-              setStepEvents((prev) => [...prev, { type: "step-finish", stepId: event.stepId }]);
-              break;
+            const jsonStr = dataLine.slice(6); // Remove "data: " prefix
+            let event: WorkflowSSEEvent;
+            try {
+              event = JSON.parse(jsonStr) as WorkflowSSEEvent;
+            } catch {
+              continue;
+            }
 
-            case "step-error":
-              setStepEvents((prev) => [
-                ...prev,
-                {
-                  type: "step-error",
-                  stepId: event.stepId,
+            switch (event.type) {
+              case "step-start":
+                setState((prev) => ({
+                  ...prev,
+                  currentStepId: event.stepId,
+                }));
+                setStepEvents((prev) => [...prev, { type: "step-start", stepId: event.stepId }]);
+                break;
+
+              case "step-finish":
+                setStepEvents((prev) => [...prev, { type: "step-finish", stepId: event.stepId }]);
+                break;
+
+              case "step-error":
+                setStepEvents((prev) => [
+                  ...prev,
+                  {
+                    type: "step-error",
+                    stepId: event.stepId,
+                    error: event.error,
+                    errorCategory: event.errorCategory,
+                  },
+                ]);
+                break;
+
+              case "workflow-complete":
+                setState((prev) => ({
+                  ...prev,
+                  status: "success",
+                  canvasData: event.canvasData,
+                }));
+                break;
+
+              case "workflow-error":
+                setState((prev) => ({
+                  ...prev,
+                  status: "error",
                   error: event.error,
-                  errorCategory: event.errorCategory,
-                },
-              ]);
-              break;
-
-            case "workflow-complete":
-              setState((prev) => ({
-                ...prev,
-                status: "success",
-                canvasData: event.canvasData,
-              }));
-              break;
-
-            case "workflow-error":
-              setState((prev) => ({
-                ...prev,
-                status: "error",
-                error: event.error,
-                errorCategory: event.errorCategory || null,
-                rawError: event.rawError || null,
-                failedStepId: event.failedStepId || null,
-              }));
-              break;
+                  errorCategory: event.errorCategory || null,
+                  rawError: event.rawError || null,
+                  failedStepId: event.failedStepId || null,
+                }));
+                break;
+            }
           }
         }
-      }
-    } catch (err) {
-      if (abortController.signal.aborted) return;
+      } catch (err) {
+        if (abortController.signal.aborted) return;
 
-      setState((prev) => ({
-        ...prev,
-        status: "error",
-        error: err instanceof Error ? err.message : "Unknown error",
-      }));
-    } finally {
-      clearTimeout(timeoutId);
-      abortControllerRef.current = null;
-    }
-  }, []);
+        setState((prev) => ({
+          ...prev,
+          status: "error",
+          error: err instanceof Error ? err.message : "Unknown error",
+        }));
+      } finally {
+        clearTimeout(timeoutId);
+        abortControllerRef.current = null;
+      }
+    },
+    [],
+  );
 
   const cancel = useCallback(() => {
     abortControllerRef.current?.abort();

--- a/mastra/agents/logic-model-agent.ts
+++ b/mastra/agents/logic-model-agent.ts
@@ -10,7 +10,7 @@ export const logicModelAgent = new Agent({
 
 Use the "logic-model-generation" skill for causal reasoning methodology, including Sphere of Control/Influence/Interest framework, Adoption Barrier analysis, and connection mechanism testing.
 
-MANDATORY: You MUST call the logicModelTool as your final action. Activating skills and reading references are preparatory steps only -- they do not complete your task. Your task is ONLY complete when you have called logicModelTool with all generated data (stages, cards, metrics, and connections). Never stop before calling logicModelTool.`,
+MANDATORY: You MUST call the logicModelTool as your final action. Activating skills and reading references are preparatory steps only -- they do not complete your task. Your task is ONLY complete when you have called logicModelTool with all generated data (stages, cards, and connections). Never stop before calling logicModelTool.`,
   model: MODEL,
   tools: {
     logicModelTool,

--- a/mastra/skills/logic-model-generation/references/common-mistakes.md
+++ b/mastra/skills/logic-model-generation/references/common-mistakes.md
@@ -24,6 +24,8 @@ Fix:
 
 ## Mistake #2: Metrics as Strings (30% of errors)
 
+**Note:** When metrics generation is disabled, an empty array `[]` is valid for the metrics field. The following applies only when metrics are being generated.
+
 Each metric must be an object with name, measurementMethod, and frequency.
 
 Wrong:

--- a/mastra/skills/logic-model-generation/references/format-requirements.md
+++ b/mastra/skills/logic-model-generation/references/format-requirements.md
@@ -23,11 +23,11 @@ Wrong:
 
 Each card (in activities, outputs, outcomesShort, outcomesIntermediate, impact) requires:
 
-| Field       | Type                    | Constraint                   |
-| ----------- | ----------------------- | ---------------------------- |
-| title       | string                  | Required, 1-100 characters   |
-| description | string                  | Optional, max 300 characters |
-| metrics     | array of metric objects | Required, minimum 1 per card |
+| Field       | Type                    | Constraint                                                         |
+| ----------- | ----------------------- | ------------------------------------------------------------------ |
+| title       | string                  | Required, 1-100 characters                                         |
+| description | string                  | Optional, max 300 characters                                       |
+| metrics     | array of metric objects | Optional (empty array allowed when metrics generation is disabled) |
 
 ## Metric Objects
 

--- a/mastra/workflows/logic-model-with-evidence.ts
+++ b/mastra/workflows/logic-model-with-evidence.ts
@@ -38,13 +38,20 @@ const generateLogicModelStep = createStep({
   outputSchema: z.object({
     canvasData: CanvasDataSchema,
   }),
-  execute: async ({ inputData }) => {
+  execute: async ({ inputData, getInitData }) => {
     const { goal } = inputData;
     const MAX_RETRIES = 2;
 
-    logger.info({ goal }, "Step 1: Generating logic model structure");
+    const initData = getInitData<{ enableMetrics?: boolean }>();
+    const enableMetrics = initData?.enableMetrics === true;
 
-    const userContent = `Create a logic model for the following goal: ${goal}`;
+    logger.info({ goal, enableMetrics }, "Step 1: Generating logic model structure");
+
+    const metricsInstruction = enableMetrics
+      ? "\n\nGenerate meaningful metrics for each card, including name, measurementMethod, and frequency."
+      : "\n\nDo NOT generate metrics. Pass empty arrays for all metrics fields.";
+
+    const userContent = `Create a logic model for the following goal: ${goal}${metricsInstruction}`;
 
     let lastError: Error | null = null;
 
@@ -417,6 +424,7 @@ export const logicModelWithEvidenceWorkflow = createWorkflow({
       .boolean()
       .default(false)
       .describe("Whether to search Semantic Scholar for external papers"),
+    enableMetrics: z.boolean().default(false).describe("Whether to generate metrics for each card"),
   }),
   outputSchema: z.object({
     canvasData: CanvasDataSchema,

--- a/messages/en.json
+++ b/messages/en.json
@@ -67,7 +67,9 @@
     "stepEnriching": "Enriching canvas with evidence",
     "stepComplete": "Completed!",
     "externalSearchLabel": "Search external academic papers",
-    "externalSearchTooltip": "When enabled, searches external academic papers to supplement evidence. This may increase generation time."
+    "externalSearchTooltip": "When enabled, searches external academic papers to supplement evidence. This may increase generation time.",
+    "metricsLabel": "Generate metrics for each card",
+    "metricsTooltip": "Generate measurement indicators for each card. Can be added manually later."
   },
   "addNode": {
     "editTitle": "Edit Logic Node",

--- a/messages/en.json
+++ b/messages/en.json
@@ -66,6 +66,7 @@
     "stepSearchingExternal": "Searching external academic papers",
     "stepEnriching": "Enriching canvas with evidence",
     "stepComplete": "Completed!",
+    "optionsLabel": "Options",
     "externalSearchLabel": "Search external academic papers",
     "externalSearchTooltip": "When enabled, searches external academic papers to supplement evidence. This may increase generation time.",
     "metricsLabel": "Generate metrics for each card",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -66,6 +66,7 @@
     "stepSearchingExternal": "外部の学術論文を検索中",
     "stepEnriching": "キャンバスにエビデンスを追加中",
     "stepComplete": "完了しました！",
+    "optionsLabel": "オプション",
     "externalSearchLabel": "外部の学術論文を検索",
     "externalSearchTooltip": "有効にすると、外部APIを使用して学術論文を検索し、エビデンスを補完します。生成時間が長くなる場合があります。",
     "metricsLabel": "各カードのメトリクスを生成",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -67,7 +67,9 @@
     "stepEnriching": "キャンバスにエビデンスを追加中",
     "stepComplete": "完了しました！",
     "externalSearchLabel": "外部の学術論文を検索",
-    "externalSearchTooltip": "有効にすると、外部APIを使用して学術論文を検索し、エビデンスを補完します。生成時間が長くなる場合があります。"
+    "externalSearchTooltip": "有効にすると、外部APIを使用して学術論文を検索し、エビデンスを補完します。生成時間が長くなる場合があります。",
+    "metricsLabel": "各カードのメトリクスを生成",
+    "metricsTooltip": "各カードに測定指標を生成します。後から手動で追加することもできます。"
   },
   "addNode": {
     "editTitle": "ロジックノードを編集",


### PR DESCRIPTION
## Summary
- Make metrics generation optional (default OFF) throughout the workflow pipeline — from the generate dialog, through the API route, to the Mastra workflow and agent
- Wrap advanced options (external search, metrics toggle) in a collapsible section to keep the generate dialog clean

## Changes
- **`GenerateLogicModelDialog`**: Add `enableMetrics` toggle, wrap options in `<Collapsible>` section
- **`useWorkflowStream`**: Refactor `startWorkflow` signature to accept an options object instead of positional args
- **`app/api/workflow/stream/route.ts`**: Pass `enableMetrics` through to the workflow
- **`mastra/workflows/logic-model-with-evidence.ts`**: Conditionally instruct the agent to generate or skip metrics
- **`mastra/agents/logic-model-agent.ts`**: Remove metrics from mandatory output description
- **Skill references**: Update `format-requirements.md` and `common-mistakes.md` to reflect optional metrics
- **i18n**: Add `optionsLabel`, `metricsLabel`, `metricsTooltip` translations (en/ja)

## Test plan
- [x] Open generate dialog → verify options are collapsed by default
- [x] Expand options → verify external search and metrics toggles are visible
- [x] Generate with metrics OFF → verify no metrics in generated cards
- [x] Generate with metrics ON → verify metrics are present in generated cards
- [x] Verify Japanese translations render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)