### PR TITLE
feat: enhance evidence search with external paper integration

### DIFF
--- a/app/api/evidence/search/route.ts
+++ b/app/api/evidence/search/route.ts
@@ -4,7 +4,11 @@ import { BASE_URL, EVIDENCE_SEARCH_MAX_STEPS } from "@/lib/constants";
 import { searchExternalPapers } from "@/lib/external-paper-search";
 import { createLogger } from "@/lib/logger";
 import { mastra } from "@/mastra";
-import { EvidenceSearchRequestSchema, type EvidenceSearchResponse } from "@/types";
+import {
+  EvidenceSearchRequestSchema,
+  type EvidenceSearchResponse,
+  type ExternalPaper,
+} from "@/types";
 
 const logger = createLogger({ module: "api:evidence-search" });
 
@@ -54,12 +58,21 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Run internal evidence search and external paper search in parallel
-    const internalSearchPromise = agent.generate(
-      [
-        {
-          role: "user",
-          content: `Search for evidence related to: "${query}"
+    // Step 1: Fetch external papers first (fast, 1-3s from Semantic Scholar)
+    let externalPapers: ExternalPaper[] = [];
+    if (includeExternalPapers) {
+      try {
+        externalPapers = await searchExternalPapers(query, limit);
+      } catch (error) {
+        logger.warn(
+          { error: error instanceof Error ? error.message : String(error) },
+          "External paper search failed, continuing with internal only",
+        );
+      }
+    }
+
+    // Step 2: Build user prompt with external paper context
+    let userPrompt = `Search for evidence related to: "${query}"
 
 Please:
 1. Call the get-all-evidence tool to load the evidence repository
@@ -70,45 +83,29 @@ Please:
 Format each result with a clickable link using evidenceId:
 Example: [View details](${BASE_URL}/evidence/08) for evidenceId "08"
 
-Respond in the same language as the query.`,
-        },
-      ],
-      { maxSteps: EVIDENCE_SEARCH_MAX_STEPS },
-    );
+Respond in the same language as the query.`;
 
-    const externalSearchPromise = includeExternalPapers
-      ? searchExternalPapers(query, limit)
-      : Promise.resolve([]);
-
-    const [internalResult, externalResult] = await Promise.allSettled([
-      internalSearchPromise,
-      externalSearchPromise,
-    ]);
-
-    // Handle internal search result
-    if (internalResult.status === "rejected") {
-      throw internalResult.reason;
+    if (externalPapers.length > 0) {
+      userPrompt += `\n\n---\n## External Academic Papers (Reference Only)\n\nThe following papers were found via Semantic Scholar. These are NOT validated internal evidence. Use them to supplement your response if internal evidence is insufficient.\n\n${formatExternalPapersForPrompt(externalPapers)}`;
     }
 
-    // Build response
+    // Step 3: Run agent with enriched prompt
+    const result = await agent.generate([{ role: "user", content: userPrompt }], {
+      maxSteps: EVIDENCE_SEARCH_MAX_STEPS,
+    });
+
+    // Step 4: Build response
     const response: EvidenceSearchResponse = {
-      response: internalResult.value.text,
+      response: result.text,
       query,
     };
 
-    // Attach external papers if requested (always set array, even if empty)
     if (includeExternalPapers) {
-      response.externalPapers = externalResult.status === "fulfilled" ? externalResult.value : [];
-      if (externalResult.status === "rejected") {
-        logger.warn(
-          { error: externalResult.reason },
-          "External paper search failed, returning internal results only",
-        );
-      }
+      response.externalPapers = externalPapers;
     }
 
     return NextResponse.json(response);
-  } catch (error) {
+  } catch (error: unknown) {
     logger.error(
       { error: error instanceof Error ? error.message : String(error) },
       "Evidence search error",
@@ -118,4 +115,39 @@ Respond in the same language as the query.`,
       { status: 500 },
     );
   }
+}
+
+/**
+ * Format external papers into a concise text block for the agent prompt.
+ */
+function formatExternalPapersForPrompt(papers: ExternalPaper[]): string {
+  return papers
+    .map((paper, i) => {
+      const authors = paper.authors?.length
+        ? paper.authors.length > 3
+          ? `${paper.authors.slice(0, 3).join(", ")} et al.`
+          : paper.authors.join(", ")
+        : "Unknown authors";
+      const year = paper.year ? ` (${paper.year})` : "";
+      const summary =
+        paper.tldr ||
+        (paper.abstract
+          ? paper.abstract.length > 150
+            ? paper.abstract.slice(0, 150) + "..."
+            : paper.abstract
+          : "No summary available");
+      const citations = paper.citationCount != null ? `Citations: ${paper.citationCount}` : "";
+      const url = paper.url ? `URL: ${paper.url}` : "";
+
+      return [
+        `${i + 1}. **${paper.title}**${year}`,
+        `   Authors: ${authors}`,
+        citations ? `   ${citations}` : "",
+        `   Summary: ${summary}`,
+        url ? `   ${url}` : "",
+      ]
+        .filter(Boolean)
+        .join("\n");
+    })
+    .join("\n\n");
 }

--- a/lib/academic-apis/extract-search-keywords.ts
+++ b/lib/academic-apis/extract-search-keywords.ts
@@ -1,6 +1,5 @@
-import { google } from "@ai-sdk/google";
-import { generateText } from "ai";
 import { createLogger } from "@/lib/logger";
+import { keywordExtractionAgent } from "@/mastra/agents/keyword-extraction-agent";
 
 const logger = createLogger({ module: "lib:extract-search-keywords" });
 
@@ -35,23 +34,9 @@ export async function extractSearchKeywords(
   const toContext = toDescription ? `${toTitle} - ${toDescription}` : toTitle;
 
   try {
-    const { text } = await generateText({
-      model: google("gemini-2.5-flash"),
-      prompt: `You are extracting search queries for Semantic Scholar to find academic evidence supporting a causal link in a Theory of Change logic model.
+    const result = await keywordExtractionAgent.generate(`From: ${fromContext}\nTo: ${toContext}`);
 
-Context: This is a causal arrow in an evidence-based impact model connecting an activity/output to an outcome. The goal is to find peer-reviewed research validating this causal relationship.
-
-From: ${fromContext}
-To: ${toContext}
-
-Generate TWO search queries in English:
-1. "keywords": 3-5 English academic keywords covering the core research concepts, methods, or interventions
-2. "causal": A natural-language query phrasing the causal relationship (e.g., "effect of [intervention] on [outcome]", "impact of [activity] on [indicator]")
-
-Return ONLY valid JSON: {"keywords": "...", "causal": "..."}`,
-    });
-
-    const cleaned = text
+    const cleaned = result.text
       .trim()
       .replace(/^```json\s*/, "")
       .replace(/\s*```$/, "");

--- a/lib/external-paper-search.ts
+++ b/lib/external-paper-search.ts
@@ -1,3 +1,5 @@
+import { google } from "@ai-sdk/google";
+import { generateText } from "ai";
 import type { ExternalPaper } from "@/types";
 import { extractSearchKeywords } from "@/lib/academic-apis/extract-search-keywords";
 import { searchSemanticScholar } from "@/lib/academic-apis/semantic-scholar";
@@ -109,6 +111,48 @@ function rankByQuality(papers: ExternalPaper[]): ExternalPaper[] {
 }
 
 // ---------------------------------------------------------------------------
+// Query translation
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a string is primarily ASCII (English).
+ */
+function isPrimarilyEnglish(text: string): boolean {
+  const nonWhitespace = text.replace(/\s/g, "");
+  if (!nonWhitespace) return true;
+  const asciiCount = [...nonWhitespace].filter((c) => c.charCodeAt(0) < 128).length;
+  return asciiCount / nonWhitespace.length > 0.8;
+}
+
+/**
+ * Translate a non-English query to English academic search keywords.
+ * Uses the same AI SDK pattern as extract-search-keywords.ts.
+ * Falls back to the original query on failure.
+ */
+async function translateToEnglishQuery(query: string): Promise<string> {
+  if (isPrimarilyEnglish(query)) return query;
+
+  try {
+    const { text } = await generateText({
+      model: google("gemini-2.5-flash"),
+      prompt: `Translate the following search query into English academic search keywords suitable for Semantic Scholar. Return ONLY the English search query, nothing else.\n\nQuery: ${query}`,
+    });
+
+    const translated = text.trim();
+    if (!translated) {
+      logger.warn({ query }, "Translation returned empty, using original");
+      return query;
+    }
+
+    logger.debug({ original: query, translated }, "Query translated to English");
+    return translated;
+  } catch (error) {
+    logger.warn({ error, query }, "Query translation failed, using original");
+    return query;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Main search functions
 // ---------------------------------------------------------------------------
 
@@ -185,7 +229,8 @@ export async function searchExternalPapersForEdge(
 /**
  * Search external academic databases using a free-text query.
  * Used by the evidence search API for user-facing queries.
- * Deterministic (no LLM calls). Results are cached for 24 hours.
+ * Non-English queries are translated to English via LLM for better results.
+ * Results are cached for 24 hours.
  */
 export async function searchExternalPapers(
   query: string,
@@ -202,9 +247,12 @@ export async function searchExternalPapers(
     return cached.slice(0, maxResults);
   }
 
-  const lastSpace = trimmed.lastIndexOf(" ", 200);
+  // Translate non-English queries to English for better Semantic Scholar results
+  const translated = await translateToEnglishQuery(trimmed);
+
+  const lastSpace = translated.lastIndexOf(" ", 200);
   const searchQuery =
-    trimmed.length > 200 ? trimmed.slice(0, lastSpace > 0 ? lastSpace : 200) : trimmed;
+    translated.length > 200 ? translated.slice(0, lastSpace > 0 ? lastSpace : 200) : translated;
 
   const papers = await searchSemanticScholar(searchQuery, maxResults);
   const deduplicated = deduplicateByDoi(papers);

--- a/lib/external-paper-search.ts
+++ b/lib/external-paper-search.ts
@@ -1,5 +1,3 @@
-import { google } from "@ai-sdk/google";
-import { generateText } from "ai";
 import type { ExternalPaper } from "@/types";
 import { extractSearchKeywords } from "@/lib/academic-apis/extract-search-keywords";
 import { searchSemanticScholar } from "@/lib/academic-apis/semantic-scholar";
@@ -10,6 +8,7 @@ import {
   MAX_EXTERNAL_PAPERS_PER_EDGE,
 } from "@/lib/constants";
 import { createLogger } from "@/lib/logger";
+import { queryTranslationAgent } from "@/mastra/agents/query-translation-agent";
 
 const logger = createLogger({ module: "lib:external-paper-search" });
 
@@ -133,12 +132,11 @@ async function translateToEnglishQuery(query: string): Promise<string> {
   if (isPrimarilyEnglish(query)) return query;
 
   try {
-    const { text } = await generateText({
-      model: google("gemini-2.5-flash"),
-      prompt: `Translate the following search query into English academic search keywords suitable for Semantic Scholar. Return ONLY the English search query, nothing else.\n\nQuery: ${query}`,
-    });
+    const result = await queryTranslationAgent.generate(
+      `Translate the following search query into English academic search keywords suitable for Semantic Scholar. Return ONLY the English search query, nothing else.\n\nQuery: ${query}`,
+    );
 
-    const translated = text.trim();
+    const translated = result.text.trim();
     if (!translated) {
       logger.warn({ query }, "Translation returned empty, using original");
       return query;

--- a/mastra/agents/conversation-bot-agent.ts
+++ b/mastra/agents/conversation-bot-agent.ts
@@ -40,7 +40,23 @@ Always include clickable links to evidence detail pages using evidenceId.
 Link format: ${BASE_URL}/evidence/[evidenceId]
 Example: [View details](${BASE_URL}/evidence/08)
 
-Always respond in the same language the user uses.`,
+Always respond in the same language the user uses.
+
+## When No Internal Evidence Is Found
+
+- Do NOT list or mention what categories, fields, or topics of evidence are currently available in the MUSE repository.
+- Do NOT suggest searching other databases (e.g., Google Scholar, CiNii, J-STAGE).
+- Focus solely on answering the user's question using available information (including external papers if provided).
+
+## External Academic Papers
+
+When external academic papers from Semantic Scholar are provided in the user message:
+
+1. **Internal evidence takes priority.** If internal evidence matches the query, present it first using the standard format.
+2. **When NO internal evidence is found**, use external papers to provide a helpful response. Do NOT say "no evidence found" or "evidence is not available" if external papers are provided.
+3. **Always clearly distinguish** between internal evidence (validated by the MUSE platform, with strength ratings and detail page links) and external academic papers (reference only, from Semantic Scholar, not reviewed by the platform).
+4. **Do NOT assign** Maryland SMS strength ratings to external papers.
+5. When referencing external papers, include: paper title, authors, year, and URL.`,
   model: MODEL,
   tools: {
     getAllEvidenceTool,

--- a/mastra/agents/keyword-extraction-agent.ts
+++ b/mastra/agents/keyword-extraction-agent.ts
@@ -1,0 +1,30 @@
+import { Agent } from "@mastra/core/agent";
+
+const FLASH_MODEL = process.env.FLASH_MODEL || "google/gemini-2.5-flash";
+
+/**
+ * Keyword Extraction Agent
+ *
+ * Lightweight agent that extracts English academic search queries from
+ * logic model card content for Semantic Scholar lookups.
+ *
+ * Generates two complementary queries:
+ * 1. keywords: Core academic concepts (3-5 terms)
+ * 2. causal: Natural-language causal relationship phrase
+ *
+ * Used by:
+ * - lib/academic-apis/extract-search-keywords.ts — extractSearchKeywords()
+ */
+export const keywordExtractionAgent = new Agent({
+  id: "keyword-extraction-agent",
+  name: "Keyword Extraction Agent",
+  instructions: `You extract search queries for Semantic Scholar to find academic evidence supporting causal links in Theory of Change logic models.
+
+Given a "From" node and a "To" node, generate TWO search queries in English:
+1. "keywords": 3-5 English academic keywords covering the core research concepts, methods, or interventions
+2. "causal": A natural-language query phrasing the causal relationship (e.g., "effect of [intervention] on [outcome]", "impact of [activity] on [indicator]")
+
+Return ONLY valid JSON: {"keywords": "...", "causal": "..."}
+Do not add explanations, formatting, markdown, or any other text.`,
+  model: FLASH_MODEL,
+});

--- a/mastra/agents/query-translation-agent.ts
+++ b/mastra/agents/query-translation-agent.ts
@@ -1,0 +1,23 @@
+import { Agent } from "@mastra/core/agent";
+
+const FLASH_MODEL = process.env.FLASH_MODEL || "google/gemini-2.5-flash";
+
+/**
+ * Query Translation Agent
+ *
+ * Lightweight agent that translates non-English search queries into
+ * English academic search keywords for Semantic Scholar lookups.
+ *
+ * Uses a fast model (gemini-2.5-flash by default) since the task
+ * is simple text translation, not complex reasoning.
+ *
+ * Used by:
+ * - lib/external-paper-search.ts — translateToEnglishQuery()
+ */
+export const queryTranslationAgent = new Agent({
+  id: "query-translation-agent",
+  name: "Query Translation Agent",
+  instructions:
+    "You translate search queries into English academic search keywords suitable for Semantic Scholar. Return ONLY the English search query, nothing else. Do not add explanations, formatting, or any other text.",
+  model: FLASH_MODEL,
+});

--- a/mastra/index.ts
+++ b/mastra/index.ts
@@ -9,7 +9,9 @@ import {
 } from "@mastra/observability";
 import { conversationBotAgent } from "./agents/conversation-bot-agent";
 import { evidenceSearchAgent } from "./agents/evidence-search-agent";
+import { keywordExtractionAgent } from "./agents/keyword-extraction-agent";
 import { logicModelAgent } from "./agents/logic-model-agent";
+import { queryTranslationAgent } from "./agents/query-translation-agent";
 import { logicModelWithEvidenceWorkflow } from "./workflows/logic-model-with-evidence";
 
 // TODO: validate CONNECTION_URL for production
@@ -53,7 +55,13 @@ const observability = new Observability({
 });
 
 export const mastra = new Mastra({
-  agents: { logicModelAgent, evidenceSearchAgent, conversationBotAgent },
+  agents: {
+    logicModelAgent,
+    evidenceSearchAgent,
+    conversationBotAgent,
+    queryTranslationAgent,
+    keywordExtractionAgent,
+  },
   workflows: { logicModelWithEvidenceWorkflow },
   workspace,
   storage,


### PR DESCRIPTION
## Summary
- Integrate Semantic Scholar API for external academic paper search alongside internal evidence
- Add multi-query search strategy with LLM-powered keyword extraction and quality ranking
- Replace Vercel AI SDK (`ai` + `@ai-sdk/google`) with dedicated Mastra agents (`queryTranslationAgent`, `keywordExtractionAgent`) to unify all LLM calls under the Mastra framework
- Add SSE-based workflow streaming, i18n support, and various UX improvements

## New Mastra Agents
Both use `FLASH_MODEL` env var (default `google/gemini-2.5-flash`), independent from the existing `MODEL` env var for the pro agents.

- `queryTranslationAgent` — translates non-English queries to English academic keywords for Semantic Scholar
- `keywordExtractionAgent` — extracts structured JSON (keywords + causal phrase) from logic model card content

## Design notes
- Agents are imported **directly from their definition files** (not via `mastra.getAgent()`) in `lib/` to avoid the circular dependency chain `mastra/index.ts → workflows → lib/external-paper-search.ts`.
- External paper search now runs **before** the conversation agent so results can be injected into the prompt. This trades ~1-3s latency for better answers when internal evidence is missing.

## Test plan
All API routes tested against a live dev server (full results in PR thread).

- [x] `POST /api/evidence/search` with Japanese query and `includeExternalPapers: true` → translation + 3 external papers returned
- [x] `POST /api/evidence/search` with English query → translation skip path works, 2 internal + 2 external returned
- [x] `POST /api/workflow/stream` with `enableExternalSearch: true` → all 4 steps (generate → search → external → enrich) complete; 22 arrows, 15/22 with external papers (45 total)
- [x] `POST /api/compact` → full workflow + IPFS upload completed in 46s (HTTP 200)
- [x] `GET /api/og/evidence` → 81KB PNG returned (HTTP 200)
- [x] `GET /api/og/canvas` → proper CID validation (HTTP 400 on invalid CID)
- [x] `GET /api/hypercerts/[id]` → reachable, existing error handling behavior preserved
- [x] `bun run build` and `bun lint` pass without errors

## Notes
- Transient `generate-logic-model` failures during testing were due to Gemini Pro high-demand throttling (unrelated to these changes); retries succeeded.
- `@ai-sdk/google` and `ai` are no longer imported from `lib/` code; they remain installed because Mastra uses them internally.