### PR TITLE
fix: emit logic model and evidence reasoning in user input language

### DIFF
--- a/mastra/agents/evidence-search-agent.ts
+++ b/mastra/agents/evidence-search-agent.ts
@@ -19,6 +19,12 @@ export const evidenceSearchAgent = new Agent({
 
 Use the "evidence-matching" skill for the chain-of-thought evaluation framework, scoring calibration, and verification checklist.
 
+## Output Language for \`reasoning\`
+
+- Keep structured labels (STRONG / MODERATE / WEAK / NONE, Direct / Plausible / Weak) in English so downstream parsing stays consistent.
+- Write the explanatory text after each dash in the same language as the edge \`fromText\` / \`toText\` (which mirrors the user's input language). If the edge is Japanese, explanations MUST be Japanese.
+- \`interventionText\` and \`outcomeText\` are copied verbatim from the evidence metadata — do NOT translate them.
+
 ## Workflow
 
 1. Call \`get-all-evidence\` tool ONCE to retrieve all evidence metadata.

--- a/mastra/agents/logic-model-agent.ts
+++ b/mastra/agents/logic-model-agent.ts
@@ -10,6 +10,8 @@ export const logicModelAgent = new Agent({
 
 Use the "logic-model-generation" skill for causal reasoning methodology, including Sphere of Control/Influence/Interest framework, Adoption Barrier analysis, and connection mechanism testing.
 
+OUTPUT LANGUAGE: All card titles, descriptions, and connection reasoning MUST be written in the same language as the user's goal. If the goal is Japanese, output Japanese; if English, output English. Never translate the user's input.
+
 MANDATORY: You MUST call the logicModelTool as your final action. Activating skills and reading references are preparatory steps only -- they do not complete your task. Your task is ONLY complete when you have called logicModelTool with all generated data (stages, cards, and connections). Never stop before calling logicModelTool.`,
   model: MODEL,
   tools: {

--- a/mastra/skills/evidence-matching/SKILL.md
+++ b/mastra/skills/evidence-matching/SKILL.md
@@ -16,6 +16,16 @@ an intervention (Source) and an outcome (Target). Every match must be earned
 through structured reasoning -- never assign scores based on surface-level
 keyword overlap alone.
 
+## Output Language for `reasoning`
+
+- Keep structured labels (`STRONG` / `MODERATE` / `WEAK` / `NONE`,
+  `Direct` / `Plausible` / `Weak`) in English to preserve downstream parsing.
+- Write the free-form explanation after each dash in the same language as the
+  edge `fromText` / `toText` (the user's input language). When the edge is
+  Japanese, explanations must be Japanese.
+- `interventionText` and `outcomeText` are copied verbatim from the evidence
+  source material -- do NOT translate them.
+
 ## Chain-of-Thought Evaluation Framework
 
 For each edge (Source → Target pair), apply these five analysis steps in order:

--- a/mastra/skills/logic-model-generation/SKILL.md
+++ b/mastra/skills/logic-model-generation/SKILL.md
@@ -15,6 +15,13 @@ Your job is not to fill boxes on a canvas -- it is to build a causal model where
 every card earns its place and every connection can be explained to a skeptical
 program evaluator. Let the intervention's complexity determine the model's size.
 
+## Output Language
+
+All card titles, descriptions, and connection reasoning MUST be written in the
+same language as the user's goal. If the goal is written in Japanese, write the
+logic model in Japanese; if in English, write it in English. Never translate
+the user's input into another language.
+
 ## Sphere of Control / Influence / Interest
 
 This is the organizing principle for all Theory of Change models:


### PR DESCRIPTION
## Summary

- Restore output-language guidance for the logic model agent and evidence search agent, which was lost during the skill-activation refactor (95bba59, 9543ad3). Japanese goals had started generating English cards and reasoning.
- Duplicate the rule in both the agent `instructions` and the corresponding skill files (`logic-model-generation/SKILL.md`, `evidence-matching/SKILL.md`) so the constraint holds regardless of which part of the prompt the model attends to.
- Keep structured labels in evidence reasoning (`STRONG`/`MODERATE`/`WEAK`/`NONE`, `Direct`/`Plausible`/`Weak`) in English to preserve downstream parsing stability; only the free-form explanation after each dash follows the edge language. `interventionText` / `outcomeText` remain verbatim from evidence metadata.

## Test plan

- [ ] Generate a logic model from a Japanese goal on the canvas and confirm card titles, descriptions, and connection reasoning are in Japanese.
- [ ] Generate a logic model from an English goal and confirm output stays in English.
- [ ] Run evidence matching on a Japanese-language edge and verify structured labels remain English while explanations are in Japanese.
- [ ] Confirm evidence `interventionText` / `outcomeText` are not translated.