### PR TITLE
feat(canvas): note that uploaded files are not stored

### DIFF
--- a/components/canvas/GenerateLogicModelDialog.tsx
+++ b/components/canvas/GenerateLogicModelDialog.tsx
@@ -494,6 +494,7 @@ export function GenerateLogicModelDialog({ onGenerate }: GenerateLogicModelDialo
                   )}
                 />
                 <p className="text-muted-foreground text-xs">{t("fileHintProposal")}</p>
+                <p className="text-muted-foreground text-xs">{t("fileNotStored")}</p>
               </TabsContent>
             </Tabs>
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -79,6 +79,7 @@
     "fileMaxSizePdf": "PDF up to {size}",
     "fileMaxSizeImage": "Images up to {size}",
     "fileHintProposal": "Upload a grant application or program proposal. We'll turn it into a logic model and flag arrows that lack supporting evidence.",
+    "fileNotStored": "Your file is processed in memory and never stored on our servers.",
     "fileRequired": "Please select a file",
     "fileTypeInvalid": "Unsupported file type. Allowed: PDF, PNG, JPG, WebP.",
     "fileTooLarge": "File is too large."

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -79,6 +79,7 @@
     "fileMaxSizePdf": "PDF は {size} まで",
     "fileMaxSizeImage": "画像は {size} まで",
     "fileHintProposal": "助成金申請書や事業計画書をアップロードすると、その内容をロジックモデルに起こし、エビデンスが不足している矢印を可視化します。",
+    "fileNotStored": "ファイルはメモリ上で処理され、サーバーには保存されません。",
     "fileRequired": "ファイルを選択してください",
     "fileTypeInvalid": "対応していないファイル形式です。PDF・PNG・JPG・WebP を選択してください。",
     "fileTooLarge": "ファイルサイズが大きすぎます。"


### PR DESCRIPTION
## Summary
- Add a privacy-reassurance line under the file upload dropzone in the Generate Logic Model dialog (`components/canvas/GenerateLogicModelDialog.tsx`).
- The new line surfaces that uploaded PDFs and images are processed in memory and forwarded to the model — never persisted on our servers.
- Translation keys `generate.fileNotStored` added to both `messages/en.json` and `messages/ja.json`.

The 4 MB upper limit is already documented in the UI (`fileMaxSizePdf` / `fileMaxSizeImage`) and in `docs/api-routes.md` / `docs/mastra-agents.md`, so this PR only addresses the missing "not stored" guidance.

Closes #250

## Test plan
- [x] `bun dev` and open `/en/canvas` and `/ja/canvas`
- [x] Open the Generate Logic Model dialog → "From file" tab
- [x] Confirm the new line appears below `fileHintProposal` in both locales
- [x] `bun lint:check` passes
- [x] `bun run test:run` passes (58 tests)