### PR TITLE
refactor(recipe): apply React best practices to recipe surface

### DIFF
--- a/components/canvas/RecipePanel.tsx
+++ b/components/canvas/RecipePanel.tsx
@@ -1,18 +1,22 @@
 "use client";
 
+import { useMemo } from "react";
 import { AlertCircle, BookOpen, Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useCanvasState, useRecipe } from "./context";
 import { RecipeView } from "./RecipeView";
-import { collectMetricContexts, countRecipeTargetCards } from "@/lib/recipe-helpers";
+import { countRecipeMetricContexts, countRecipeTargetCards } from "@/lib/recipe-helpers";
 
 export function RecipePanel() {
   const t = useTranslations("recipe");
   const { nodes, cardMetrics } = useCanvasState();
   const recipe = useRecipe();
 
-  const targetCards = countRecipeTargetCards(nodes);
-  const metricCount = collectMetricContexts(nodes, cardMetrics).length;
+  const targetCards = useMemo(() => countRecipeTargetCards(nodes), [nodes]);
+  const metricCount = useMemo(
+    () => countRecipeMetricContexts(nodes, cardMetrics),
+    [nodes, cardMetrics],
+  );
 
   if (recipe.phase === "waiting-for-logic-model") {
     return (

--- a/components/canvas/RecipeView.tsx
+++ b/components/canvas/RecipeView.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import { AlertTriangle, ClipboardList } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -20,10 +21,14 @@ const SECTION_ORDER: RecipeTargetCardType[] = [
 export function RecipeView({ recipe, stale = false }: RecipeViewProps) {
   const t = useTranslations("recipe");
 
-  const grouped = SECTION_ORDER.map((type) => ({
-    type,
-    items: recipe.items.filter((item) => item.parentCardType === type),
-  })).filter((g) => g.items.length > 0);
+  const grouped = useMemo(
+    () =>
+      SECTION_ORDER.map((type) => ({
+        type,
+        items: recipe.items.filter((item) => item.parentCardType === type),
+      })).filter((g) => g.items.length > 0),
+    [recipe.items],
+  );
 
   const sectionLabel = (type: RecipeTargetCardType): string => {
     switch (type) {
@@ -36,7 +41,7 @@ export function RecipeView({ recipe, stale = false }: RecipeViewProps) {
     }
   };
 
-  const generatedAtLabel = (() => {
+  const generatedAtLabel = useMemo(() => {
     try {
       return new Date(recipe.generatedAt).toLocaleString(
         recipe.locale === "ja" ? "ja-JP" : "en-US",
@@ -44,7 +49,7 @@ export function RecipeView({ recipe, stale = false }: RecipeViewProps) {
     } catch {
       return recipe.generatedAt;
     }
-  })();
+  }, [recipe.generatedAt, recipe.locale]);
 
   return (
     <div className="mx-auto max-w-4xl space-y-6 p-4 sm:p-6">
@@ -124,7 +129,7 @@ function RecipeItemCard({ item }: { item: RecipeMetricGuidance }) {
             </p>
             <ol className="ml-5 list-decimal space-y-1">
               {item.measurementSteps.map((step, idx) => (
-                <li key={idx}>{step}</li>
+                <li key={`${idx}-${step.slice(0, 40)}`}>{step}</li>
               ))}
             </ol>
           </div>
@@ -145,7 +150,7 @@ function RecipeItemCard({ item }: { item: RecipeMetricGuidance }) {
             </p>
             <ul className="ml-5 list-disc space-y-0.5 text-amber-900 dark:text-amber-200">
               {item.cautions.map((c, idx) => (
-                <li key={idx}>{c}</li>
+                <li key={`${idx}-${c.slice(0, 40)}`}>{c}</li>
               ))}
             </ul>
           </div>

--- a/hooks/useRecipeStream.ts
+++ b/hooks/useRecipeStream.ts
@@ -71,6 +71,7 @@ export function useRecipeStream() {
         let buffer = "";
 
         while (true) {
+          if (abortController.signal.aborted) break;
           const { done, value } = await reader.read();
           if (done) break;
 

--- a/lib/recipe-helpers.ts
+++ b/lib/recipe-helpers.ts
@@ -49,5 +49,25 @@ export function deriveLogicModelTitle(nodes: Node<CardNodeData>[], fallback: str
 }
 
 export function countRecipeTargetCards(nodes: Node<CardNodeData>[]): number {
-  return nodes.filter((n) => isRecipeTargetType(n.data.type)).length;
+  let count = 0;
+  for (const node of nodes) {
+    if (isRecipeTargetType(node.data.type)) count++;
+  }
+  return count;
+}
+
+export function countRecipeMetricContexts(
+  nodes: Node<CardNodeData>[],
+  cardMetrics: Record<string, Metric[]>,
+): number {
+  let count = 0;
+  for (const node of nodes) {
+    if (!isRecipeTargetType(node.data.type)) continue;
+    const metrics = cardMetrics[node.id];
+    if (!metrics) continue;
+    for (const metric of metrics) {
+      if (metric.name?.trim()) count++;
+    }
+  }
+  return count;
 }

--- a/lib/recipe/storage.test.ts
+++ b/lib/recipe/storage.test.ts
@@ -64,6 +64,27 @@ describe("recipe storage", () => {
     expect(errorSpy).toHaveBeenCalled();
   });
 
+  it("persists with a version field and rejects unknown shapes", () => {
+    saveRecipeState({ recipe: sampleRecipe, stale: false });
+    const raw = localStorage.getItem("recipeState");
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw!)).toMatchObject({ version: 1 });
+  });
+
+  it("returns null and clears storage when the persisted shape is invalid", () => {
+    localStorage.setItem("recipeState", JSON.stringify({ foo: 1 }));
+    expect(loadRecipeState()).toBeNull();
+    expect(localStorage.getItem("recipeState")).toBeNull();
+  });
+
+  it("returns null when the persisted version does not match", () => {
+    localStorage.setItem(
+      "recipeState",
+      JSON.stringify({ version: 999, recipe: sampleRecipe, stale: false }),
+    );
+    expect(loadRecipeState()).toBeNull();
+  });
+
   it("swallows errors from localStorage.setItem", () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {

--- a/lib/recipe/storage.ts
+++ b/lib/recipe/storage.ts
@@ -1,4 +1,5 @@
-import type { Recipe } from "@/types";
+import { z } from "zod";
+import { RecipeSchema, type Recipe } from "@/types";
 
 export interface PersistedRecipeState {
   recipe: Recipe;
@@ -6,11 +7,18 @@ export interface PersistedRecipeState {
 }
 
 const STORAGE_KEY = "recipeState";
+const STORAGE_VERSION = 1;
+
+const PersistedRecipeStateSchema = z.object({
+  version: z.literal(STORAGE_VERSION),
+  recipe: RecipeSchema,
+  stale: z.boolean(),
+});
 
 export function saveRecipeState(state: PersistedRecipeState): void {
   try {
     if (typeof window === "undefined") return;
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ version: STORAGE_VERSION, ...state }));
   } catch (error) {
     console.error("Failed to save recipe state:", error);
   }
@@ -20,7 +28,14 @@ export function loadRecipeState(): PersistedRecipeState | null {
   try {
     if (typeof window === "undefined") return null;
     const saved = localStorage.getItem(STORAGE_KEY);
-    return saved ? (JSON.parse(saved) as PersistedRecipeState) : null;
+    if (!saved) return null;
+    const parsed = PersistedRecipeStateSchema.safeParse(JSON.parse(saved));
+    if (!parsed.success) {
+      localStorage.removeItem(STORAGE_KEY);
+      return null;
+    }
+    const { recipe, stale } = parsed.data;
+    return { recipe, stale };
   } catch (error) {
     console.error("Failed to load recipe state:", error);
     return null;


### PR DESCRIPTION
Memoize derived values in RecipePanel/RecipeView so high-frequency canvas updates (node drag/select) no longer rebuild grouped sections or re-allocate metric-context arrays purely for counting. Replace collectMetricContexts(...).length with a dedicated count helper. Switch list keys off raw idx to a content-prefixed composite to avoid accidental remounts. Guard the SSE event loop with an abort-signal check to prevent post-abort setState races. Version the persisted recipe payload and validate it through Zod on load, discarding stale or malformed entries instead of casting blindly.