### PR TITLE
refactor(api): configurable API base URL and shared SSE parser

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
 # Project environment
 NEXT_PUBLIC_ENV="development"
 
+# Base URL of the muse-backend service (Hono on Cloudflare Workers).
+# Leave unset to use the same-origin Next.js API routes (current behavior).
+# Do not set in production until the backend serves every migrated route.
+NEXT_PUBLIC_API_BASE_URL=""
+
 # This is used to upload contents to IPFS
 PINATA_JWT="PINATA_JWT_HERE"
 

--- a/app/[lang]/canvas/mint-hypercert/page.tsx
+++ b/app/[lang]/canvas/mint-hypercert/page.tsx
@@ -3,7 +3,6 @@ import { useState, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { formatHypercertData, TransferRestrictions } from "@hypercerts-org/sdk";
-import { track } from "@vercel/analytics";
 import { format } from "date-fns";
 import { toPng } from "html-to-image";
 import { ArrowLeft, Loader2, CalendarIcon, Trash2 } from "lucide-react";
@@ -304,9 +303,6 @@ export default function MintHypercertPage() {
       try {
         hypercertId = generateHypercertIdFromReceipt(receipt, chain.id);
         logger.info({ hypercertId: hypercertId || "not found" }, "Mint completed");
-        track("Mint completed", {
-          hypercertId: hypercertId || "not found",
-        });
       } catch (error) {
         logger.error(
           { error: error instanceof Error ? error.message : String(error) },

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,6 @@
         "@tailwindcss/typography": "^0.5.16",
         "@tanstack/react-query": "^5.83.0",
         "@tanstack/react-table": "^8.21.3",
-        "@vercel/analytics": "^1.5.0",
         "@xyflow/react": "^12.9.2",
         "ai": "^5.0.76",
         "class-variance-authority": "^0.7.1",
@@ -1317,8 +1316,6 @@
     "@vanilla-extract/private": ["@vanilla-extract/private@1.0.9", "", {}, "sha512-gT2jbfZuaaCLrAxwXbRgIhGhcXbRZCG3v4TTUnjw0EJ7ArdBRxkq4msNJkbuRkCgfIK5ATmprB5t9ljvLeFDEA=="],
 
     "@vanilla-extract/sprinkles": ["@vanilla-extract/sprinkles@1.6.4", "", { "peerDependencies": { "@vanilla-extract/css": "^1.0.0" } }, "sha512-lW3MuIcdIeHKX81DzhTnw68YJdL1ial05exiuvTLJMdHXQLKcVB93AncLPajMM6mUhaVVx5ALZzNHMTrq/U9Hg=="],
-
-    "@vercel/analytics": ["@vercel/analytics@1.6.1", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "react", "svelte", "vue", "vue-router"] }, "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.0.5", "", {}, "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw=="],
 

--- a/hooks/useRecipeStream.ts
+++ b/hooks/useRecipeStream.ts
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import type { ErrorCategory } from "@/lib/workflow-errors";
 import type { Recipe, RecipeMetricContext, RecipeLocale } from "@/types";
 import type { RecipeSSEEvent } from "@/types/recipe-events";
+import { apiUrl, readSSEEvents } from "@/lib/api-client";
 import { WORKFLOW_TIMEOUT_MS } from "@/lib/constants";
 
 type RecipeStreamStatus = "idle" | "running" | "success" | "error";
@@ -59,7 +60,7 @@ export function useRecipeStream() {
       }, WORKFLOW_TIMEOUT_MS + 10_000);
 
       try {
-        const response = await fetch("/api/recipe/stream", {
+        const response = await fetch(apiUrl("/api/recipe/stream"), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(input),
@@ -82,63 +83,38 @@ export function useRecipeStream() {
           throw new Error(errorMessage || `HTTP ${response.status}`);
         }
 
-        const reader = response.body?.getReader();
-        if (!reader) throw new Error("No response stream");
-
-        const decoder = new TextDecoder();
-        let buffer = "";
-
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-
-          buffer += decoder.decode(value, { stream: true });
-          const chunks = buffer.split("\n\n");
-          buffer = chunks.pop() || "";
-
-          for (const chunk of chunks) {
-            const dataLine = chunk.split("\n").find((line) => line.startsWith("data: "));
-            if (!dataLine) continue;
-
-            let event: RecipeSSEEvent;
-            try {
-              event = JSON.parse(dataLine.slice(6)) as RecipeSSEEvent;
-            } catch {
-              continue;
-            }
-
-            switch (event.type) {
-              case "step-start":
-                setState((prev) => ({ ...prev, currentStepId: event.stepId }));
-                break;
-              case "step-finish":
-                break;
-              case "step-error":
-                setState((prev) => ({
-                  ...prev,
-                  status: "error",
-                  error: event.error,
-                  errorCategory: event.errorCategory ?? null,
-                  failedStepId: event.stepId,
-                }));
-                break;
-              case "recipe-complete":
-                setState((prev) => ({
-                  ...prev,
-                  status: "success",
-                  recipe: event.recipe,
-                }));
-                break;
-              case "recipe-error":
-                setState((prev) => ({
-                  ...prev,
-                  status: "error",
-                  error: event.error,
-                  errorCategory: event.errorCategory ?? null,
-                  failedStepId: event.failedStepId ?? null,
-                }));
-                break;
-            }
+        for await (const event of readSSEEvents<RecipeSSEEvent>(response)) {
+          switch (event.type) {
+            case "step-start":
+              setState((prev) => ({ ...prev, currentStepId: event.stepId }));
+              break;
+            case "step-finish":
+              break;
+            case "step-error":
+              setState((prev) => ({
+                ...prev,
+                status: "error",
+                error: event.error,
+                errorCategory: event.errorCategory ?? null,
+                failedStepId: event.stepId,
+              }));
+              break;
+            case "recipe-complete":
+              setState((prev) => ({
+                ...prev,
+                status: "success",
+                recipe: event.recipe,
+              }));
+              break;
+            case "recipe-error":
+              setState((prev) => ({
+                ...prev,
+                status: "error",
+                error: event.error,
+                errorCategory: event.errorCategory ?? null,
+                failedStepId: event.failedStepId ?? null,
+              }));
+              break;
           }
         }
       } catch (err) {

--- a/hooks/useWorkflowStream.ts
+++ b/hooks/useWorkflowStream.ts
@@ -4,6 +4,7 @@ import { useCallback, useRef, useState } from "react";
 import type { ErrorCategory } from "@/lib/workflow-errors";
 import type { CanvasData } from "@/types";
 import type { WorkflowSSEEvent } from "@/types/workflow-events";
+import { apiUrl, readSSEEvents } from "@/lib/api-client";
 import { WORKFLOW_TIMEOUT_MS } from "@/lib/constants";
 
 type WorkflowStreamStatus = "idle" | "running" | "success" | "error";
@@ -110,87 +111,57 @@ export function useWorkflowStream() {
                 signal: abortController.signal,
               };
 
-        const response = await fetch("/api/workflow/stream", fetchInit);
+        const response = await fetch(apiUrl("/api/workflow/stream"), fetchInit);
 
         if (!response.ok) {
           const errorBody = await response.json().catch(() => ({}));
           throw new Error((errorBody as Record<string, string>).error || `HTTP ${response.status}`);
         }
 
-        const reader = response.body?.getReader();
-        if (!reader) {
-          throw new Error("No response stream");
-        }
+        for await (const event of readSSEEvents<WorkflowSSEEvent>(response)) {
+          switch (event.type) {
+            case "step-start":
+              setState((prev) => ({
+                ...prev,
+                currentStepId: event.stepId,
+              }));
+              setStepEvents((prev) => [...prev, { type: "step-start", stepId: event.stepId }]);
+              break;
 
-        const decoder = new TextDecoder();
-        let buffer = "";
+            case "step-finish":
+              setStepEvents((prev) => [...prev, { type: "step-finish", stepId: event.stepId }]);
+              break;
 
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-
-          buffer += decoder.decode(value, { stream: true });
-
-          // Parse SSE lines
-          const lines = buffer.split("\n\n");
-          buffer = lines.pop() || "";
-
-          for (const chunk of lines) {
-            const dataLine = chunk.split("\n").find((line) => line.startsWith("data: "));
-            if (!dataLine) continue;
-
-            const jsonStr = dataLine.slice(6); // Remove "data: " prefix
-            let event: WorkflowSSEEvent;
-            try {
-              event = JSON.parse(jsonStr) as WorkflowSSEEvent;
-            } catch {
-              continue;
-            }
-
-            switch (event.type) {
-              case "step-start":
-                setState((prev) => ({
-                  ...prev,
-                  currentStepId: event.stepId,
-                }));
-                setStepEvents((prev) => [...prev, { type: "step-start", stepId: event.stepId }]);
-                break;
-
-              case "step-finish":
-                setStepEvents((prev) => [...prev, { type: "step-finish", stepId: event.stepId }]);
-                break;
-
-              case "step-error":
-                setStepEvents((prev) => [
-                  ...prev,
-                  {
-                    type: "step-error",
-                    stepId: event.stepId,
-                    error: event.error,
-                    errorCategory: event.errorCategory,
-                  },
-                ]);
-                break;
-
-              case "workflow-complete":
-                setState((prev) => ({
-                  ...prev,
-                  status: "success",
-                  canvasData: event.canvasData,
-                }));
-                break;
-
-              case "workflow-error":
-                setState((prev) => ({
-                  ...prev,
-                  status: "error",
+            case "step-error":
+              setStepEvents((prev) => [
+                ...prev,
+                {
+                  type: "step-error",
+                  stepId: event.stepId,
                   error: event.error,
-                  errorCategory: event.errorCategory || null,
-                  rawError: event.rawError || null,
-                  failedStepId: event.failedStepId || null,
-                }));
-                break;
-            }
+                  errorCategory: event.errorCategory,
+                },
+              ]);
+              break;
+
+            case "workflow-complete":
+              setState((prev) => ({
+                ...prev,
+                status: "success",
+                canvasData: event.canvasData,
+              }));
+              break;
+
+            case "workflow-error":
+              setState((prev) => ({
+                ...prev,
+                status: "error",
+                error: event.error,
+                errorCategory: event.errorCategory || null,
+                rawError: event.rawError || null,
+                failedStepId: event.failedStepId || null,
+              }));
+              break;
           }
         }
       } catch (err) {

--- a/lib/api-client.test.ts
+++ b/lib/api-client.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { apiUrl, readSSEEvents } from "./api-client";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("apiUrl", () => {
+  it("returns the path unchanged when NEXT_PUBLIC_API_BASE_URL is unset", () => {
+    vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", "");
+    expect(apiUrl("/api/workflow/stream")).toBe("/api/workflow/stream");
+  });
+
+  it("prefixes the configured base URL", () => {
+    vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", "https://api.example.com");
+    expect(apiUrl("/api/workflow/stream")).toBe("https://api.example.com/api/workflow/stream");
+  });
+
+  it("strips trailing slashes from the base URL", () => {
+    vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", "https://api.example.com/");
+    expect(apiUrl("/api/compact")).toBe("https://api.example.com/api/compact");
+  });
+});
+
+function sseResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream);
+}
+
+async function collect<T>(response: Response): Promise<T[]> {
+  const events: T[] = [];
+  for await (const event of readSSEEvents<T>(response)) {
+    events.push(event);
+  }
+  return events;
+}
+
+describe("readSSEEvents", () => {
+  it("parses events, including ones split across chunks", async () => {
+    const response = sseResponse([
+      'data: {"type":"step-start","stepId":"a"}\n\ndata: {"ty',
+      'pe":"step-finish","stepId":"a"}\n\n',
+    ]);
+    expect(await collect(response)).toEqual([
+      { type: "step-start", stepId: "a" },
+      { type: "step-finish", stepId: "a" },
+    ]);
+  });
+
+  it("skips chunks without a data line and invalid JSON payloads", async () => {
+    const response = sseResponse([
+      ': comment\n\ndata: not-json\n\ndata: {"type":"workflow-complete"}\n\n',
+    ]);
+    expect(await collect(response)).toEqual([{ type: "workflow-complete" }]);
+  });
+
+  it("discards a trailing partial chunk when the stream ends", async () => {
+    const response = sseResponse(['data: {"type":"done"}\n\ndata: {"type":"tru']);
+    expect(await collect(response)).toEqual([{ type: "done" }]);
+  });
+
+  it("throws when the response has no body", async () => {
+    const response = new Response(null);
+    await expect(collect(response)).rejects.toThrow("No response stream");
+  });
+});

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -1,0 +1,51 @@
+/**
+ * Base-URL indirection for the API routes that migrate to the muse-backend
+ * service.
+ *
+ * NEXT_PUBLIC_API_BASE_URL unset → same-origin (the current Next.js routes).
+ * Do not set it in production until the backend serves every migrated route.
+ */
+export function apiUrl(path: string): string {
+  const base = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
+  return `${base.replace(/\/+$/, "")}${path}`;
+}
+
+/**
+ * Parse a text/event-stream response body into typed events.
+ *
+ * Shared by useWorkflowStream and useRecipeStream, which consume the custom
+ * SSE contract (`data: {...}\n\n`) of the workflow routes. Invalid JSON
+ * payloads are skipped and a trailing partial chunk is discarded when the
+ * stream ends — the same semantics as the inline parsers this replaces.
+ */
+export async function* readSSEEvents<T>(response: Response): AsyncGenerator<T> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    throw new Error("No response stream");
+  }
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const chunks = buffer.split("\n\n");
+    buffer = chunks.pop() || "";
+
+    for (const chunk of chunks) {
+      const dataLine = chunk.split("\n").find((line) => line.startsWith("data: "));
+      if (!dataLine) continue;
+
+      let event: T;
+      try {
+        event = JSON.parse(dataLine.slice(6)) as T;
+      } catch {
+        continue;
+      }
+      yield event;
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@tailwindcss/typography": "^0.5.16",
     "@tanstack/react-query": "^5.83.0",
     "@tanstack/react-table": "^8.21.3",
-    "@vercel/analytics": "^1.5.0",
     "@xyflow/react": "^12.9.2",
     "ai": "^5.0.76",
     "class-variance-authority": "^0.7.1",

--- a/utils/ipfs.ts
+++ b/utils/ipfs.ts
@@ -1,4 +1,5 @@
 import { CID } from "multiformats/cid";
+import { apiUrl } from "@/lib/api-client";
 import { MAX_CANVAS_SIZE } from "@/lib/constants";
 import { CanvasData, CanvasDataSchema, IPFSStorageResult } from "@/types";
 
@@ -41,7 +42,7 @@ export async function uploadToIPFS(canvasData: CanvasData): Promise<IPFSStorageR
   try {
     const filename = `canvas-${canvasData.id}.json`;
 
-    const response = await fetch("/api/upload-to-ipfs", {
+    const response = await fetch(apiUrl("/api/upload-to-ipfs"), {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -110,7 +111,7 @@ export async function uploadImageToIPFS(blob: Blob, filename: string): Promise<s
   formData.append("file", blob, filename);
   formData.append("filename", filename);
 
-  const response = await fetch("/api/upload-image-to-ipfs", {
+  const response = await fetch(apiUrl("/api/upload-image-to-ipfs"), {
     method: "POST",
     body: formData,
   });


### PR DESCRIPTION
Phase 0-A (T6 / T7) of the backend rearchitecture: prepare the frontend to talk to the standalone `muse-backend` service (Hono on Cloudflare Workers) without changing any behavior yet.

## 1. Configurable API base URL

New `lib/api-client.ts` exposes `apiUrl(path)`, which prefixes `NEXT_PUBLIC_API_BASE_URL` when it is set and falls back to same-origin otherwise. Applied to the five call sites whose routes move to the backend:

- `hooks/useWorkflowStream.ts` — `/api/workflow/stream`
- `hooks/useRecipeStream.ts` — `/api/recipe/stream`
- `utils/ipfs.ts` — `/api/upload-to-ipfs`, `/api/upload-image-to-ipfs`

With the variable unset (the default, and what `.env.example` documents) every request goes to the same origin, so this is a no-op until the switch is flipped. Do not set it in production until the backend serves every migrated route.

## 2. Shared SSE parser

The two stream hooks each carried their own copy of the `data: {...}\n\n` parser. Both now consume `readSSEEvents<T>(response)`, an async generator in the same module. Semantics are preserved: payloads that fail `JSON.parse` are skipped, and a trailing partial chunk is discarded when the stream ends. The large diff in the hooks is mostly de-indentation — the event `switch` bodies are unchanged.

## 3. Drop `@vercel/analytics`

One `track()` call in the mint-hypercert page and the dependency itself. It was the only Vercel-specific runtime import in the app.

The remaining Vercel specifics stay for now, because the routes they belong to keep running on Vercel until the backend takes over: `maxDuration` in three route handlers and the `process.env.VERCEL` branch in `mastra/index.ts`.

## Verification

- `bun run lint:check` — clean
- `bun run test:run` — 119 tests pass, including the new `lib/api-client.test.ts`
- The full flow (logic model generation → recipe → both IPFS uploads) was exercised through the UI against a local backend at `localhost:8787`, and separately against the current same-origin routes

`bunx tsc --noEmit` reports one error in `lib/evidence-filters.test.ts:79`. It predates this branch and is unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)