### PR TITLE
feat(worker): serve staging on dev.muse.beaconlabs.io

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -217,10 +217,27 @@ Notes:
 Two Workers, both on the `beaconlabs-admin` account (`account_id` is pinned in
 `wrangler.jsonc` so a deploy can never land on a personal account):
 
-| Branch | wrangler env | Worker                  | Triggered by            |
-| ------ | ------------ | ----------------------- | ----------------------- |
-| `dev`  | `staging`    | `muse-frontend-staging` | a PR merged into `dev`  |
-| `main` | `production` | `muse-frontend-prod`    | a PR merged into `main` |
+| Branch | wrangler env | Worker                  | Served at                        | Triggered by            |
+| ------ | ------------ | ----------------------- | -------------------------------- | ----------------------- |
+| `dev`  | `staging`    | `muse-frontend-staging` | `dev.muse.beaconlabs.io`         | a PR merged into `dev`  |
+| `main` | `production` | `muse-frontend-prod`    | workers.dev only (#300 half-way) | a PR merged into `main` |
+
+Staging's hostname is a **custom domain** declared in `wrangler.jsonc`
+(`env.staging.routes`), which makes Cloudflare own its DNS record — a proxied
+placeholder `AAAA` it creates on attach. Production is still on Vercel:
+`muse.beaconlabs.io` keeps its CNAME there, and its cutover is the remaining
+half of #300.
+
+Two things to know before touching either hostname:
+
+- Cloudflare refuses to attach a custom domain to a hostname that already has
+  an externally managed DNS record (error 100117), which is what the Vercel
+  CNAME on `dev.muse.beaconlabs.io` was. Delete the record first, then deploy;
+  adding one back by hand breaks the attached domain. CI deploys
+  non-interactively, so a conflict fails the merge rather than prompting.
+- Declaring any route flips wrangler's workers.dev default to **off**, and the
+  PR preview URLs live on that same subdomain. `workers_dev: true` next to the
+  route is what keeps them up.
 
 Deploys are **merge-driven**: `.github/workflows/deploy-worker.yml` runs on
 `pull_request: closed` and does nothing unless the PR was actually merged. A
@@ -276,15 +293,15 @@ Two tripwires guard that layering before a production build starts:
 must differ from the repository-level (staging) value — each failure is exactly
 what a missing production override looks like.
 
-#### Known gap until the domain cutover (#300)
+#### Known gap for PR previews (#300)
 
 The backend allows CORS origins by exact match (`ALLOWED_ORIGINS`), and its
-staging list holds `https://dev.muse.beaconlabs.io`, not the Worker's
-workers.dev URL. Until #300 points the domains at these Workers, staging and PR
-previews render and route correctly but every backend call from the browser is
-blocked — treat them as build, routing and SSG checks. Preview URLs are dynamic
-and can never be listed exactly, so functional previews would need the backend
-to match by suffix instead.
+staging list holds `https://dev.muse.beaconlabs.io`. Staging answers on exactly
+that origin now, so its backend calls pass. **PR previews still do not**: their
+URLs are per-PR workers.dev hostnames that no exact-match list can cover, so a
+preview renders and routes correctly while every backend call from the browser
+is blocked — treat previews as build, routing and SSG checks. Making them
+functional would need the backend to match by suffix instead.
 
 ## i18n
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -43,12 +43,26 @@
   // account_id) is an inheritable key and cascades from the top level — unlike
   // `vars`, which would have to be restated per environment if this app had any.
   "env": {
-    // dev branch → https://muse-frontend-staging.<subdomain>.workers.dev
+    // dev branch → https://dev.muse.beaconlabs.io (workers.dev stays up too)
     // PR previews are uploaded as versions of this Worker.
     "staging": {
       "name": "muse-frontend-staging",
       // Required for the versioned/aliased preview URLs used by PR previews.
       "preview_urls": true,
+      // Stated explicitly because the `routes` entry below flips the default:
+      // wrangler disables workers.dev on any Worker that declares a route,
+      // which would take the preview URLs (same subdomain) down with it.
+      "workers_dev": true,
+      // #300, staging half. This is the origin the backend's staging
+      // ALLOWED_ORIGINS lists, so browser calls only pass CORS from here,
+      // never from the workers.dev URL. `custom_domain` means Cloudflare owns
+      // this hostname's DNS record: the record it manages is created on
+      // attach, and adding any record for the hostname by hand breaks it.
+      // Cloudflare refuses the attach outright while an externally managed
+      // record exists (error 100117), which is what the former Vercel CNAME
+      // did until it was deleted — and CI deploys non-interactively, so such
+      // a conflict fails every merge into `dev` rather than prompting.
+      "routes": [{ "pattern": "dev.muse.beaconlabs.io", "custom_domain": true }],
     },
     // main branch → https://muse-frontend-prod.<subdomain>.workers.dev
     // The custom domain is attached in #300; until then this workers.dev URL is


### PR DESCRIPTION
Points `dev.muse.beaconlabs.io` at the `muse-frontend-staging` Worker, replacing the CNAME that pointed at Vercel. First half of #300.

**The domain is already attached** — a config-only PR could not do it, since Cloudflare refuses to create a custom domain while an externally managed DNS record exists (error 100117) and CI deploys non-interactively, so the attach had to happen once the Vercel CNAME was deleted. This PR brings the repo in line with that state, so future deploys re-assert the same routing instead of dropping it.

## Why

The backend's staging `ALLOWED_ORIGINS` lists `https://dev.muse.beaconlabs.io` by exact match. As long as workers.dev was staging's only entry point, every backend call from the browser was CORS-blocked — staging could be checked for build, routing and SSG, but not used. That gap is what `docs/setup.md` described; it now applies to PR previews only, whose per-PR hostnames no exact-match list can cover.

## Changes

- `wrangler.jsonc` — `env.staging` gains the `custom_domain` route, plus an explicit `workers_dev: true`. The flag is load-bearing: declaring any route flips wrangler's workers.dev default to **off**, and the PR preview URLs live on that same subdomain, so leaving it implicit takes previews down.
- `docs/setup.md` — records the serving host per environment, both hostname pitfalls above, and narrows the #300 gap section to previews.

## Verified against the live deployment

| Check | Result |
| --- | --- |
| Custom domain | `dev.muse.beaconlabs.io → muse-frontend-staging` |
| DNS | Cloudflare-managed proxied `AAAA 100::`; no Vercel remnant; 1.1.1.1 and 8.8.8.8 both resolve |
| `GET /` | `307 → /en` |
| `GET /en`, `/ja`, `/en/effects` | `200`, `server: cloudflare`, no `x-vercel-*` |
| `GET /en/evidence/<slug>` | `200` + `<article>` — the prerender cache is populated |
| Unknown path | `404` |
| CORS preflight from `https://dev.muse.beaconlabs.io` | `access-control-allow-origin` returned; the workers.dev origin still gets none, as documented |
| Backend link shapes `/evidence/00`, `/canvas/<hash>` | `307 → /en/...` |
| workers.dev + a version preview URL | both `200` |

No backend change is needed: `ALLOWED_ORIGINS` and `APP_BASE_URL` already named this hostname, and only the host it resolved to was wrong.

## Known issue, not introduced here

Verification surfaced #306: the Workers Free plan's 10 ms CPU limit makes the `next/og` routes and the heavier dynamic pages fail intermittently with `exceededCpu` (HTTP 503 / error 1102). It reproduces identically on the untouched workers.dev hostname, so it is independent of this change — but it does block the production half of #300.

Refs #300. Production (`muse.beaconlabs.io`) stays on Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2wWAqeD1eS1EdVn6HXn6r
